### PR TITLE
Update's added to horse racing page.

### DIFF
--- a/src/app/horseRoom/page.tsx
+++ b/src/app/horseRoom/page.tsx
@@ -1,14 +1,41 @@
 "use client"
 
 import { useRouter } from "next/navigation"
+import { useEffect, useState, useRef } from "react"
 import { Button } from "~/components/ui/button"
 import { Card } from "~/components/ui/card"
-import { ChevronLeft, Circle } from "lucide-react"
+import { ChevronLeft, Circle, ChevronDown, ChevronUp } from "lucide-react"
 
 export default function HorseRoomPage() {
   const router = useRouter()
+  const [userBets, setUserBets] = useState<
+    { raceId: number; horseId: number; amount: number; potentialWin: number }[]
+  >([])
+  const [expanded, setExpanded] = useState(false)
+  const [chatOpen, setChatOpen] = useState(true)
+  const [messages, setMessages] = useState<
+    { id: number; text?: string; image?: string; timestamp: string }[]
+  >([])
+  const [chatInput, setChatInput] = useState("")
+  const [modalImage, setModalImage] = useState<string | null>(null)
+  const chatEndRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
-  // Mock race data
+  useEffect(() => {
+    const stored = localStorage.getItem("userBets")
+    if (stored) {
+      try {
+        setUserBets(JSON.parse(stored))
+      } catch {
+        console.error("Invalid stored bets")
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (chatOpen) chatEndRef.current?.scrollIntoView({ behavior: "smooth" })
+  }, [messages, chatOpen])
+
   const race = {
     id: 1,
     name: "Churchill Downs Classic",
@@ -18,116 +45,252 @@ export default function HorseRoomPage() {
       { id: 3, name: "Storm Chaser", odds: 5.8, color: "bg-green-500", totalBets: 1200 },
       { id: 4, name: "Wind Runner", odds: 6.5, color: "bg-yellow-500", totalBets: 950 },
       { id: 5, name: "Fire Dancer", odds: 7.2, color: "bg-purple-500", totalBets: 800 },
+      { id: 6, name: "Ocean Wave", odds: 8.0, color: "bg-cyan-500", totalBets: 500 },
+      { id: 7, name: "Mountain King", odds: 9.5, color: "bg-orange-500", totalBets: 450 },
+      { id: 8, name: "Desert Fox", odds: 12.0, color: "bg-pink-500", totalBets: 300 },
     ],
   }
 
-  // Example bet (mocked)
-  const bets = [{ raceId: 1, horseId: 2, amount: 100, potentialWin: 420 }]
-
-  // Sort by best odds
   const sortedHorses = [...race.horses].sort((a, b) => a.odds - b.odds)
 
+  const handleSendMessage = () => {
+    if (!chatInput.trim()) return
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: prev.length + 1,
+        text: chatInput,
+        timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+      },
+    ])
+    setChatInput("")
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault()
+      handleSendMessage()
+    }
+  }
+
+  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: prev.length + 1,
+          image: reader.result as string,
+          timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+        },
+      ])
+    }
+    reader.readAsDataURL(file)
+  }
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    const items = e.clipboardData.items
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      if (item.type.indexOf("image") !== -1) {
+        const file = item.getAsFile()
+        if (!file) continue
+        const reader = new FileReader()
+        reader.onload = () => {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: prev.length + 1,
+              image: reader.result as string,
+              timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+            },
+          ])
+        }
+        reader.readAsDataURL(file)
+        e.preventDefault()
+      }
+    }
+  }
+
+  const toggleCLO = () => {
+    if (expanded) {
+      setExpanded(false)
+      setChatOpen(true)
+    } else {
+      setExpanded(true)
+      setChatOpen(false)
+    }
+  }
+
+  const openChat = () => {
+    setChatOpen(true)
+    setExpanded(false)
+  }
+
   return (
-    <div className="min-h-screen flex flex-col pb-16 bg-background text-foreground">
-      {/* ===== Header ===== */}
+    <div className="min-h-screen flex flex-col bg-background text-foreground">
       <header className="border-b border-border bg-card sticky top-0 z-40">
-        <div className="w-full px-6 py-4 flex items-center gap-3">
+        <div className="w-full max-w-lg mx-auto px-4 py-3 flex items-center gap-2">
           <Button variant="ghost" size="icon" onClick={() => router.back()}>
             <ChevronLeft className="h-5 w-5" />
           </Button>
-          <h1 className="text-xl font-bold">Horse Room</h1>
+          <h1 className="text-lg font-bold">{race.name}</h1>
         </div>
       </header>
 
-      {/* ===== Content Sections ===== */}
-      <main className="flex-1 w-full flex flex-col divide-y divide-border">
-        {/* Top Section (2/5) */}
-        <section className="flex-[2] flex items-center justify-center p-6">
-          <Card className="w-full h-full flex items-center justify-center bg-gradient-to-br from-primary/10 to-secondary/30 shadow-sm">
-            <h2 className="text-lg font-bold">{race.name}</h2>
-          </Card>
-        </section>
+      <main className="flex-1 w-full max-w-lg mx-auto flex flex-col p-3 gap-2">
+        {/* Animation */}
+        <div className="w-full bg-gradient-to-br from-primary/10 to-secondary/20 rounded-lg shadow-md aspect-video flex items-center justify-center">
+          <h2 className="text-lg font-bold text-muted-foreground">Animation Placeholder</h2>
+        </div>
 
-        {/* Middle Section (2/5) - Live Odds */}
-        <section className="flex-[2] overflow-y-auto p-6">
-          <Card className="w-full h-full bg-gradient-to-br from-secondary/10 to-primary/20 p-5 shadow-sm overflow-y-auto">
-            <h2 className="text-lg font-bold mb-4 text-center">Current Live Odds</h2>
-            <div className="space-y-3">
-              {sortedHorses.map((horse, index) => {
-                const userBet = bets.find(
-                  (b) => b.horseId === horse.id && b.raceId === race.id
-                )
+        {/* CLO */}
+        <Card className="w-full p-2 shadow-sm">
+          <div className="flex justify-between items-center mb-2">
+            <h2 className="text-md font-bold flex-1">Current Live Odds</h2>
+            <Button variant="ghost" size="sm" onClick={toggleCLO} className="flex items-center gap-1 text-sm">
+              {expanded ? (
+                <span className="flex items-center gap-1">Show Less <ChevronUp className="h-3 w-3" /></span>
+              ) : (
+                <span className="flex items-center gap-1">Show All <ChevronDown className="h-3 w-3" /></span>
+              )}
+            </Button>
+          </div>
 
-                return (
-                  <div
-                    key={horse.id}
-                    className={`p-3 rounded-lg transition-all ${
-                      userBet
-                        ? "ring-2 ring-primary/70 bg-primary/5"
-                        : "hover:bg-secondary/30"
-                    }`}
-                  >
-                    {/* Top Row: horse info and total bets */}
-                    <div className="flex items-center justify-between">
-                      {/* Left: number, name, odds */}
-                      <div className="flex items-center gap-3">
-                        <div
-                          className={`w-9 h-9 rounded-md ${horse.color} flex items-center justify-center text-white font-bold`}
-                        >
-                          {index + 1}
-                        </div>
-                        <div className="flex items-center gap-2">
-                          {userBet && (
-                            <Circle className="h-3 w-3 text-green-500 fill-green-500" />
-                          )}
-                          <h3 className="font-semibold text-base">{horse.name}</h3>
-                          <p className="text-sm text-muted-foreground">{horse.odds}x</p>
-                        </div>
-                      </div>
-
-                      {/* Right: total bets */}
-                      <div className="text-right">
-                        <p className="text-xs text-muted-foreground">Total</p>
-                        <p className="text-sm font-semibold">
-                          {horse.totalBets.toLocaleString()}
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* User bet info (below) */}
-                    {userBet && (
-                      <div className="mt-2 pl-12 text-sm text-muted-foreground">
-                        <div className="flex justify-between">
-                          <span>Your Bet:</span>
-                          <span className="font-semibold text-foreground">
-                            {userBet.amount} coins
-                          </span>
-                        </div>
-                        <div className="flex justify-between">
-                          <span>Potential Win:</span>
-                          <span className="font-semibold text-primary">
-                            {userBet.potentialWin} coins
-                          </span>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                )
+          {/* Collapsed CLO */}
+          {!expanded && (
+            <div className="flex justify-evenly py-1">
+              {sortedHorses.slice(0, 3).map((horse, index) => {
+                const userBet = userBets.find(b => b.horseId === horse.id && b.raceId === race.id)
+                return <HorseRowCollapsed key={horse.id} horse={horse} index={index} userBet={userBet} />
               })}
             </div>
-          </Card>
-        </section>
+          )}
 
-        {/* Bottom Section (1/5) - Chat Button */}
-        <section className="flex-[1] flex items-center justify-center p-6">
-          <Button
-            className="w-full text-base py-3 rounded-lg shadow-md"
-            onClick={() => console.log("Chat opened")}
-          >
+          {/* Expanded CLO */}
+          {expanded && (
+            <div className="flex flex-col gap-1 max-h-56 overflow-y-auto pr-1 scrollbar-thin scrollbar-thumb-white scrollbar-track-gray-800">
+              {sortedHorses.map((horse, index) => {
+                const userBet = userBets.find(b => b.horseId === horse.id && b.raceId === race.id)
+                return <HorseRowExpanded key={horse.id} horse={horse} index={index} userBet={userBet} />
+              })}
+            </div>
+          )}
+        </Card>
+
+        {/* Show Chat button when CLO expanded */}
+        {expanded && !chatOpen && (
+          <Button className="w-full py-2 rounded-lg shadow-md text-sm" onClick={openChat}>
             Open Chat
           </Button>
-        </section>
+        )}
+
+        {/* Chat */}
+        {chatOpen && (
+          <Card className="w-full h-64 p-2 flex flex-col bg-black text-white shadow-md">
+            {/* Chat header */}
+            <div className="text-sm font-bold mb-1 border-b border-gray-700 pb-1">
+              Chat
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-2 space-y-1 scrollbar-thin scrollbar-thumb-white scrollbar-track-gray-800">
+              {messages.map((msg) => (
+                <div key={msg.id} className="border-b border-gray-700 pb-1 text-xs">
+                  <span className="text-gray-400 mr-1">{msg.timestamp}</span>
+                  {msg.text && <span>{msg.text}</span>}
+                  {msg.image && (
+                    <img
+                      src={msg.image}
+                      alt="uploaded"
+                      className="mt-1 max-h-24 rounded-md cursor-pointer"
+                      onClick={() => setModalImage(msg.image)}
+                    />
+                  )}
+                </div>
+              ))}
+              <div ref={chatEndRef} />
+            </div>
+
+            <div className="flex items-center gap-1 mt-1">
+              <input
+                ref={inputRef}
+                type="text"
+                placeholder="Type a message..."
+                value={chatInput}
+                onChange={(e) => setChatInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
+                className="flex-1 p-1 rounded-md border border-gray-600 bg-gray-900 text-white text-sm"
+              />
+              <label className="cursor-pointer p-1 bg-gray-800 rounded-md text-sm">
+                📎
+                <input type="file" accept="image/*" onChange={handleImageUpload} className="hidden" />
+              </label>
+              <Button size="sm" onClick={handleSendMessage}>Send</Button>
+            </div>
+          </Card>
+        )}
+
+
+        {/* Image Modal */}
+        {modalImage && (
+          <div
+            className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50"
+            onClick={() => setModalImage(null)}
+          >
+            <div className="relative flex flex-col items-center" onClick={(e) => e.stopPropagation()}>
+              {/* Close button above the image */}
+              <button
+                className="mb-2 text-white bg-gray-800 rounded-full px-2 py-1 text-lg font-bold"
+                onClick={() => setModalImage(null)}
+              >
+                ✕
+              </button>
+              <img src={modalImage} alt="modal" className="max-h-[80vh] max-w-[90vw] rounded-md" />
+            </div>
+          </div>
+        )}
       </main>
+    </div>
+  )
+}
+
+// Collapsed row
+function HorseRowCollapsed({ horse, index, userBet }: { horse: any; index: number; userBet?: { amount: number; potentialWin: number } }) {
+  return (
+    <div className="flex flex-col items-center text-center p-1 rounded-lg min-w-[80px]">
+      <div className="flex items-center gap-1 mb-1">
+        {userBet && <Circle className="h-3 w-3 text-green-500 fill-green-500" />}
+        <div className={`w-6 h-6 rounded-md ${horse.color} flex items-center justify-center text-white text-sm font-bold`}>{index + 1}</div>
+        <div className="flex flex-col text-left ml-1">
+          <span className="text-xs font-semibold">{horse.name}</span>
+          <span className="text-[10px] text-muted-foreground">Total: {horse.totalBets.toLocaleString()}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Expanded row
+function HorseRowExpanded({ horse, index, userBet }: { horse: any; index: number; userBet?: { amount: number; potentialWin: number } }) {
+  return (
+    <div className="p-1 rounded-lg flex flex-col transition-all">
+      <div className="flex items-center gap-2 mb-1">
+        {userBet && <Circle className="h-3 w-3 text-green-500 fill-green-500" />}
+        <div className={`w-6 h-6 rounded-md ${horse.color} flex items-center justify-center text-white text-sm font-bold`}>{index + 1}</div>
+        <div className="font-semibold text-sm">{horse.name}</div>
+      </div>
+      <div className="text-[10px] text-muted-foreground ml-6">
+        <div>Total: {horse.totalBets.toLocaleString()} coins</div>
+        {userBet && (
+          <>
+            <div>Your Bet: {userBet.amount} coins</div>
+            <div className="text-green-500">Potential Win: {userBet.potentialWin} coins</div>
+          </>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Updates added to the horse racing page with better sizing for multiple devices.
<img width="1440" height="776" alt="image" src="https://github.com/user-attachments/assets/a5f552a0-16ef-481e-8653-de74fc0c02dc" />

There is now a 16:9 placeholder for the animation for better positioning when it gets added. 
<img width="522" height="285" alt="image" src="https://github.com/user-attachments/assets/65b1b469-076e-49d6-b2c6-4dc4e8c9d7fa" />

The current live odds section has been changed to now display a smaller format when the chat is opened. It will now only show the top three horses and the total amount bet to give more room for the chat. This is done so that the user does not have to scroll to reach the chat section. A green dot also now appears on every horse that the user has placed a bet on.
<img width="508" height="129" alt="image" src="https://github.com/user-attachments/assets/71009cc9-153b-4081-9ac2-0d832a7806f6" />
When the "Show All" button is clicked, the current live odds get extended, and it will now show all of the horses along with any bets the user has made in a scrollable fashion. The chat section also gets removed and is replaced with just an "Open Chat" button.  
<img width="502" height="348" alt="image" src="https://github.com/user-attachments/assets/b2bd0d52-c913-496d-b4df-0dc91f13566c" />

Finally, the chat feature is now working. Messages that the user sends are shown in the chat box with a time stamp. Images can also be sent, and when clicked on, they expand so users can see them if they are too small to see in the chat box. 
<img width="504" height="269" alt="image" src="https://github.com/user-attachments/assets/3a14bdfa-9117-4746-abc2-c25a8c49f794" />

A future push request is going to combine both race page files to include the dynamic changes of the horses' information.